### PR TITLE
feat: add AUR support with GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,44 @@
+name: Build to test PR
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvulkan-dev libgl-dev libx11-dev gcc make
+      - name: Build binary
+        run: make
+      - name: Create tarball
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH_NAME="x86_64"
+          elif [ "$ARCH" = "aarch64" ]; then
+            ARCH_NAME="aarch64"
+          fi
+          mkdir -p krosshair-linux-${ARCH_NAME}
+          cp lib/krosshair.so krosshair-linux-${ARCH_NAME}/
+          cp krosshair.json krosshair-linux-${ARCH_NAME}/
+          tar -czf krosshair-linux-${ARCH_NAME}.tar.gz -C krosshair-linux-${ARCH_NAME} .
+      - name: Generate checksum
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH_NAME="x86_64"
+          elif [ "$ARCH" = "aarch64" ]; then
+            ARCH_NAME="aarch64"
+          fi
+          sha256sum krosshair-linux-${ARCH_NAME}.tar.gz > krosshair-linux-${ARCH_NAME}.sha256
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: krosshair-linux
+          path: |
+            krosshair-linux-*.tar.gz
+            krosshair-linux-*.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,154 @@
+name: Semantic Versioning and Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python python-pip
+          pip install --user bumpver
+      - name: Calculate version bump
+        id: bump
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            COMMITS=$(git log $LAST_TAG..HEAD --pretty=%s)
+          else
+            COMMITS=$(git log HEAD --pretty=%s)
+          fi
+          if echo "$COMMITS" | grep -q "^BREAKING CHANGE:"; then
+            bumpver update --major
+          elif echo "$COMMITS" | grep -q "^feat:"; then
+            bumpver update --minor
+          else
+            bumpver update --patch
+          fi
+          NEW_VERSION=$(bumpver show | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: Bump PKGBUILD versions
+        run: |
+          sed -i "s/pkgver=.*/pkgver=${{ steps.bump.outputs.new_version }}/" PKGBUILD
+          sed -i "s/pkgver=.*/pkgver=${{ steps.bump.outputs.new_version }}/" aur/PKGBUILD
+      - name: Upload version files (uncommitted)
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-files
+          path: |
+            PKGBUILD
+            aur/
+
+  build:
+    needs: [version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: version-files
+          path: .
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvulkan-dev libgl-dev libx11-dev gcc make
+      - name: Build binary
+        run: make
+      - name: Determine architecture
+        id: arch
+        run: |
+          ARCH=$(uname -m)
+          echo "arch=$ARCH" >> $GITHUB_OUTPUT
+          if [ "$ARCH" = "x86_64" ]; then
+            echo "arch_name=x86_64" >> $GITHUB_OUTPUT
+          elif [ "$ARCH" = "aarch64" ]; then
+            echo "arch_name=aarch64" >> $GITHUB_OUTPUT
+          fi
+      - name: Create tarball
+        run: |
+          mkdir -p krosshair-linux-${{ steps.arch.outputs.arch_name }}
+          cp lib/krosshair.so krosshair-linux-${{ steps.arch.outputs.arch_name }}/
+          cp krosshair.json krosshair-linux-${{ steps.arch.outputs.arch_name }}/
+          tar -czf krosshair-linux-${{ steps.arch.outputs.arch_name }}.tar.gz -C krosshair-linux-${{ steps.arch.outputs.arch_name }} .
+      - name: Generate checksum
+        run: sha256sum krosshair-linux-${{ steps.arch.outputs.arch_name }}.tar.gz > krosshair-linux-${{ steps.arch.outputs.arch_name }}.sha256
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: krosshair-linux-${{ steps.arch.outputs.arch_name }}
+          path: |
+            krosshair-linux-*.tar.gz
+            krosshair-linux-*.sha256
+
+  commit-and-release:
+    needs: [version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Restore version files from successful build
+        run: |
+          mkdir -p aur
+          cp artifacts/version-files/PKGBUILD .
+          cp -r artifacts/version-files/aur/* aur/
+      - name: Commit version bump and create tag
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add PKGBUILD aur/
+          git commit -m "chore: bump version to v${{ needs.version.outputs.new_version }}" || echo "No changes to commit"
+          git tag "v${{ needs.version.outputs.new_version }}" -f
+          git push origin main
+          git push origin "v${{ needs.version.outputs.new_version }}" -f
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to AUR
+        run: |
+          mkdir -p ~/.ssh
+          echo "$AUR_SSH_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          ssh-keyscan aur.archlinux.org >> ~/.ssh/known_hosts
+          rm -rf aur
+          git clone ssh://aur@aur.archlinux.org/krosshair.git aur
+          cp -r artifacts/version-files/aur/* aur/
+          cd aur
+          makepkg --printsrcinfo > .SRCINFO
+          git config user.name "GitHub Action"
+          git config user.email "action@github.com"
+          git add PKGBUILD .SRCINFO krosshair.install
+          git commit -m "Update to v${{ needs.version.outputs.new_version }}" || echo "No changes to commit"
+          git push origin master
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+      - name: Create release with assets
+        run: |
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH_NAME="x86_64"
+          elif [ "$ARCH" = "aarch64" ]; then
+            ARCH_NAME="aarch64"
+          fi
+          gh release delete "v${{ needs.version.outputs.new_version }}" --yes 2>/dev/null || true
+          gh release create "v${{ needs.version.outputs.new_version }}" \
+            --title "v${{ needs.version.outputs.new_version }}" \
+            --notes "Release v${{ needs.version.outputs.new_version }}" \
+            artifacts/krosshair-linux-${ARCH_NAME}/krosshair-linux-${ARCH_NAME}.tar.gz \
+            artifacts/krosshair-linux-${ARCH_NAME}/krosshair-linux-${ARCH_NAME}.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,27 @@
+# Maintainer: fibsussy <noahlykins@gmail.com>
+pkgname=krosshair
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Crosshair overlay for games on linux using Vulkan"
+arch=('x86_64' 'aarch64')
+url="https://github.com/fibsussy/krosshair"
+license=('GPL3')
+depends=('vulkan-icd-loader' 'libgl' 'libx11')
+makedepends=('gcc' 'make' 'vulkan-headers')
+options=('!debug')
+
+build() {
+    cd "$startdir"
+    make
+}
+
+package() {
+    cd "$startdir"
+
+    install -Dm755 lib/krosshair.so "$pkgdir/usr/lib/krosshair/krosshair.so"
+    install -Dm644 krosshair.json "$pkgdir/usr/share/vulkan/implicit_layer.d/krosshair.json"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+    install -dm755 "$pkgdir/usr/share/krosshair/crosshairs"
+    cp -r crosshairs/* "$pkgdir/usr/share/krosshair/crosshairs/" || true
+}

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,0 +1,13 @@
+pkgbase = krosshair
+pkgdesc = Crosshair overlay for games on linux using Vulkan
+pkgver = 0.1.0
+pkgrel = 1
+url = https://github.com/fibsussy/krosshair
+arch = x86_64
+arch = aarch64
+license = GPL3
+depends = libvulkan-driver
+depends = libgl
+depends = libx11
+
+pkgname = krosshair

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,30 @@
+# Maintainer: fibsussy <noahlykins@gmail.com>
+pkgname=krosshair
+pkgver=0.1.0
+pkgrel=1
+pkgdesc="Crosshair overlay for games on linux using Vulkan"
+arch=('x86_64' 'aarch64')
+url="https://github.com/fibsussy/krosshair"
+license=('GPL3')
+depends=('vulkan-icd-loader' 'libgl' 'libx11')
+makedepends=()
+options=('!debug')
+
+_arch="$CARCH"
+if [ "$_arch" = "x86_64" ]; then
+    _arch="x86_64"
+elif [ "$_arch" = "aarch64" ]; then
+    _arch="aarch64"
+fi
+
+source=(
+    "https://github.com/fibsussy/krosshair/releases/download/v${pkgver}/krosshair-linux-${_arch}.tar.gz"
+    "LICENSE::https://raw.githubusercontent.com/fibsussy/krosshair/v${pkgver}/LICENSE"
+)
+sha256sums=('SKIP' 'SKIP')
+
+package() {
+    install -Dm755 "$srcdir/krosshair.so" "$pkgdir/usr/lib/krosshair/krosshair.so"
+    install -Dm644 "$srcdir/krosshair.json" "$pkgdir/usr/share/vulkan/implicit_layer.d/krosshair.json"
+    install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/aur/krosshair.install
+++ b/aur/krosshair.install
@@ -1,0 +1,28 @@
+post_install() {
+    echo ""
+    echo "==> krosshair installed successfully!"
+    echo ""
+    echo "==> Getting Started:"
+    echo ""
+    echo "    1. Run your game with KROSSHAIR=1 set"
+    echo "       Example: KROSSHAIR=1 your-game"
+    echo ""
+    echo "    2. For Steam games, add to launch options:"
+    echo "       KROSSHAIR=1 %command%"
+    echo ""
+    echo "==> Customization:"
+    echo "       KROSSHAIR_IMG=/path/to/crosshair.png"
+    echo "       KROSSHAIR_SCALE=1.0"
+    echo ""
+    echo "==> Sample crosshairs installed at:"
+    echo "       /usr/share/krosshair/crosshairs/"
+    echo ""
+    echo "==> For more info: https://github.com/fibsussy/krosshair"
+    echo ""
+}
+
+post_upgrade() {
+    echo ""
+    echo "==> krosshair upgraded successfully!"
+    echo ""
+}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/pr.yml` for PR builds on Ubuntu runner
- Add `.github/workflows/release.yml` for semantic versioning and releases
- Add root `PKGBUILD` for building from source on Arch
- Add `aur/` directory with AUR PKGBUILD, install script, and `.SRCINFO`
- Add proper `.gitignore`

This enables easy building on Arch Linux and AUR package submission

Build was tested locally and compiles successfully.

You can safely pull this anytime, and you can setup it to push to the AUR if you:
1. get an AUR account
2. Create a new sh ed25519 keypair
3. Add public key to your AUR account settings
4. Add the private key as `AUR_SSH_KEY` secret in GitHub repo Settings → Secrets and variables → Actions → Repository secrets. This will give the git workflow permission to push to AUR.